### PR TITLE
Autogenerating not found mocks when in mock mode. Also output mock filen...

### DIFF
--- a/lib/modes.js
+++ b/lib/modes.js
@@ -24,11 +24,11 @@ function writeResponse(path, res) {
   res.end();
 }
 
-function write404(req, res) {
+function write404(req, res, path) {
   res.writeHead(404, {
     'Content-Type': 'text/plain'
   });
-  res.write('No mock exists for ' + req.url);
+    res.write('No mock exists for ' + req.url + ' - ('+path+')');
   res.end();
 }
 
@@ -42,6 +42,19 @@ function parseJsonResponse(res, data) {
     }
   }
   return data;
+}
+function writeNotFoundFile(proxy , req , path)
+{
+    var response = {
+        requestUrl: req.url,
+        data: []
+    };
+
+    var serializedResponse = JSON.stringify(response, true, 2);
+    path += '.mocked';
+
+    // write file async to disk.  overwrite if it already exists.  prettyprint.
+    fs.writeFile(path, serializedResponse);
 }
 
 function serializeResponse(proxy, res, data) {
@@ -92,7 +105,8 @@ module.exports = {
         writeResponse(path, res);
         logSuccess('Mocked', proxy, req);
       } else {
-        write404(req, res);
+        write404(req, res, path);
+        writeNotFoundFile(proxy, req, path);
         grunt.log.verbose.writeln('Returned 404 for: ' + req.url);
       }
     });


### PR DESCRIPTION
Hello i made this PR because currently i am prototyping frontend APP from scratch. In this phase you have no backend present so you need to quick mock every request.

Problems i have found with your plugins : When mock is not found its very difficult to find how to "generate" mock for that request , if you were not previously in record mode , its difficult to manualy hash request URL to SHA1 and then create file . I have added request filename to 404 response as you can very quickly now create that filename and mock data, and also i have added autogenerating empty file with corresponding url when 404 is thrown.

In this mode you can perfectly prototype application, just try every request, files are simply pre-generated with extension ".mocked", and you can just quickly add data to them.

Let me know what you think about this.
