### PR TITLE
Autogenerating not found mocks when in mock mode. Also output mock file

### DIFF
--- a/lib/modes.js
+++ b/lib/modes.js
@@ -47,6 +47,7 @@ function writeNotFoundFile(proxy , req , path)
 {
     var response = {
         requestUrl: req.url,
+        statusCode : 200,
         data: []
     };
 


### PR DESCRIPTION
Hello i made this PR because currently i am prototyping frontend APP from scratch. In this phase you have no backend present so you need to quick mock every request.

Problems i have found with your plugins : When mock is not found its very difficult to find how to "generate" mock for that request , if you were not previously in record mode , its difficult to manualy hash request URL to SHA1 and then create file . I have added request filename to 404 response as you can very quickly now create that filename and mock data, and also i have added autogenerating empty file with corresponding url when 404 is thrown.

In this mode you can perfectly prototype application, just try every request, files are simply pre-generated with extension ".mocked", and you can just quickly add data to them.

Let me know what you think about this.
