### PR TITLE
Add proxy option 'delay' so you can simulate real world response delay

### DIFF
--- a/lib/modes.js
+++ b/lib/modes.js
@@ -82,7 +82,37 @@ function logSuccess(modeMsg, proxy, req) {
   var source = req.originalUrl;
   grunt.log.verbose.writeln(modeMsg + ' request: ' + source + ' -> ' + target + '\n' + JSON.stringify(req.headers, true, 2));
 }
+function calculateDelayTime(mode)
+{
+    if(!mode || mode === undefined)
+    {
+        return 1;
+    } else if(!isNaN(mode))
+    {
+        return mode;
+    } else
+    {
+        var lowerBound = 1;
+        var upperBound = 1;
+        switch(mode)
+        {
+            case 'auto':
+                lowerBound = 500;
+                upperBound = 1750;
+                break;
+            case 'fast' :
+                lowerBound = 150;
+                upperBound = 1000;
+                break;
+            case 'slow' :
+                lowerBound = 1500;
+                upperBound = 3000;
+                break;
+        }
+        return Math.floor((Math.random() * upperBound) + lowerBound);
+    }
 
+}
 module.exports = {
   proxy: function(proxy, req, res) {
     var target = utils.absoluteUrl(proxy, req.url);
@@ -106,8 +136,14 @@ module.exports = {
 
     fs.exists(path, function(exists) {
       if (exists) {
-        writeResponse(path, res);
-        logSuccess('Mocked', proxy, req);
+          /*** delay response with some fake time so mock has behaviour like real world API ***/
+          var scheduleResponse = calculateDelayTime(proxy.config.delay);
+          setTimeout(function()
+          {
+              writeResponse(path, res);
+              grunt.log.writeln('Response delayed by ' +  scheduleResponse  + ' ms')
+              logSuccess('Mocked', proxy, req);
+          }, scheduleResponse);
       } else {
         write404(req, res, path);
         serializeEmptyMock(proxy, req, path);


### PR DESCRIPTION
Hey , today i also came up with this idea, when you are in mock mode, responses are almost instant, which is great but when you are developing asynchronous application you need to mock responses like in real world. Now i am developing progress bar, while response is pending, but in mock mode i get response in less than 100 ms and my progress bar or whatever "please wait loading" is rarely shown up.

I added real world response simulation , you can define new option in prism section of gruntfile (on same level as you are defining context, mode and etc for proxy)

Allowed 'delay' values are :
any integer which represent delay in ms 

``` javascript
 server: {
                options: {
                    mode: 'mock',
                    context: '/api/v1',
                    delay : 1000
                }
            }

```

string 'auto' which is generating average response time (from 600 - 2000 ms)

``` javascript
 server: {
                options: {
                    mode: 'mock',
                    context: '/api/v1',
                    delay : 'auto'
                }
            }

```

string 'fast' which is generating fast  response time (from 150 - 1000 ms)

``` javascript
 server: {
                options: {
                    mode: 'mock',
                    context: '/api/v1',
                    delay : 'fast'
                }
            }

```

string 'slow' which is generating slow response time (from 1500 - 3000 ms)

``` javascript
 server: {
                options: {
                    mode: 'mock',
                    context: '/api/v1',
                    delay : 'slow'
                }
            }

```

Let me know what you think
