### PR TITLE
include small gotcha in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ In your project's Gruntfile, add a section named `prism`.
 
 ### Adding prism configuration.
 
-You can add all the options in the root task options, in a target options, or a mix of both (where the target options will inherit from the root options).
+You can add all the options in the root task options, in a target options, or a mix of both (where the target options will inherit from the root options). One thing to note: you need **at least** one configuration (ie server below) outside of the stock configuration for prism to work.
 
 ```js
   prism: {


### PR DESCRIPTION
it seems currently you need at least one configuration outside of the root settings for prism to create a default proxy. Perhaps this would be better fixed in https://github.com/seglo/grunt-connect-prism/blob/master/tasks/prism-task.js where a stock prism is created if none are provided? your call.
